### PR TITLE
Add icon to illustrate that images can be expanded.

### DIFF
--- a/assets/stylesheets/_iphone.scss
+++ b/assets/stylesheets/_iphone.scss
@@ -122,6 +122,29 @@ $padding-text: 15px;
         max-height: inherit;
     }
 
+    .alf-supports-fullscreen {
+        .media-element {
+            position: relative;
+        }
+    }
+
+    .alf-supports-fullscreen {
+        .media-element:after {
+            position: absolute;
+            content: '';
+            top: 0;
+            right: 0;
+            width: 27px;
+            height: 27px;
+            background-color: rgba(0, 0, 0, 0.4);
+            background-size: 13px;
+            background-repeat: no-repeat;
+            background-position: center;
+            background-image: url("http://static.vg.no/vgpluss/gfx/icon-fullsize.png");
+            display: block;
+        }
+    }
+
     .alf-supports-fullscreen img {
         width: 100%;
         height: auto;
@@ -273,7 +296,7 @@ $padding-text: 15px;
 
             &.media-element {
                 max-width: 320px;
-                padding-right: $padding-text;
+                margin-right: 15px;
             }
         }
     }

--- a/templates/fluid/iphone.html
+++ b/templates/fluid/iphone.html
@@ -28,7 +28,7 @@
         <div class="alf-region alf-region-flexible vg-pay">
             <div class="alf-container-inline panorama" data-map="*-large *-slim-large *-generic-large" data-match=".dp-image-size-panorama"></div>
             <div class="alf-container-inline full-width" data-map="*-small *-slim-small *-generic-small" data-match=".dp-float-left, .dp-float-right"></div>
-            <div class="alf-container-inline full-width" data-map="*-large *-slim-large *-generic-large"></div>>
+            <div class="alf-container-inline full-width" data-map="*-large *-slim-large *-generic-large"></div>
         </div>
     </div>
     <div class="alf-container-fullscreen" data-map="*-large *-*-large"></div>
@@ -50,7 +50,7 @@
         <div class="alf-region alf-region-flexible vg-pay">
             <div class="alf-container-inline panorama" data-map="*-large *-slim-large *-generic-large" data-match=".dp-image-size-panorama"></div>
             <div class="alf-container-inline full-width" data-map="*-small *-slim-small *-generic-small" data-match=".dp-float-left, .dp-float-right"></div>
-            <div class="alf-container-inline full-width" data-map="*-large *-slim-large *-generic-large"></div>>
+            <div class="alf-container-inline full-width" data-map="*-large *-slim-large *-generic-large"></div>
         </div>
     </div>
     <div class="alf-container-fullscreen" data-map="*-large *-*-large"></div>


### PR DESCRIPTION
Ideally we only want to apply this to .alf-gt600, but I could not get this selector to work (browse bug?).
